### PR TITLE
Rename: heritage -> app

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Set the following environment variables to your CI build environment:
 - `BARCELONA_ENDPOINT`
   - **Required**
   - A URL of Barcelona service e.g. `https://barcelona.your-domain.com`
-- `MAINLINE_HERITAGE_TOKEN`
+- `MAINLINE_APP_TOKEN`
   - **Required**
-  - Barcelona's heritage token for the mainline application
-- `STABLE_HERITAGE_TOKEN`
+  - Barcelona's app token for the mainline application
+- `STABLE_APP_TOKEN`
   - **Conditional** If you have stable branch this is required.
-  - Barcelona's heritage token for the stable application
+  - Barcelona's app token for the stable application
 - `QUAY_REPOSITORY`
   - **Optional**
   - A name of your quay repository. It should be `[organization]/[repo name]`. If you don't set this variable bcnd uses github repository name as a quay repository name.

--- a/lib/bcnd/ci.rb
+++ b/lib/bcnd/ci.rb
@@ -9,22 +9,22 @@ module Bcnd
     }
 
     attr_accessor :repository,
-      :commit,
-      :branch,
-      :quay_repository,
-      :quay_token,
-      :github_token,
-      :mainline_heritage_token,
-      :stable_heritage_token,
-      :stage_config
+                  :commit,
+                  :branch,
+                  :quay_repository,
+                  :quay_token,
+                  :github_token,
+                  :mainline_app_token,
+                  :stable_app_token,
+                  :stage_config
 
     def initialize
       load_ci_environment
       load_stage_config
       self.quay_token = ENV['QUAY_TOKEN']
       self.github_token = ENV['GITHUB_TOKEN']
-      self.mainline_heritage_token = ENV['MAINLINE_HERITAGE_TOKEN']
-      self.stable_heritage_token = ENV['STABLE_HERITAGE_TOKEN']
+      self.mainline_app_token = ENV['MAINLINE_APP_TOKEN'] || ENV['MAINLINE_HERITAGE_TOKEN']
+      self.stable_app_token = ENV['STABLE_APP_TOKEN'] || ENV['STABLE_HERITAGE_TOKEN']
       self.quay_repository = ENV['QUAY_REPOSITORY'] || self.repository
     end
 

--- a/lib/bcnd/runner.rb
+++ b/lib/bcnd/runner.rb
@@ -27,7 +27,7 @@ module Bcnd
       image_id = quay.docker_image_id_for_tag(repo: env.quay_repository, tag: 'latest') # FIXME
       quay.put_tag(repo: env.quay_repository, image_id: image_id, tag: env.commit)
       puts "attached tag #{env.commit} to image #{image_id}"
-      bcn_deploy(env.commit, env.mainline_heritage_token)
+      bcn_deploy(env.commit, env.mainline_app_token)
     end
 
     def deploy_stable
@@ -36,7 +36,7 @@ module Bcnd
       image_id = quay.docker_image_id_for_tag(repo: env.quay_repository, tag: tag)
       raise "There is no docker image to be deployed" unless image_id
 
-      bcn_deploy(tag, env.stable_heritage_token)
+      bcn_deploy(tag, env.stable_app_token)
     end
 
     def quay
@@ -48,7 +48,7 @@ module Bcnd
     end
 
     def bcn_deploy(tag, token)
-      system "bcn deploy -e #{env.deploy_environment} --tag #{tag} --heritage-token #{token} 1> /dev/null"
+      system "bcn deploy -e #{env.deploy_environment} --tag #{tag} --app-token #{token} 1> /dev/null"
       puts "deploy triggered with tag #{tag} to #{env.deploy_environment} environment"
       if $?.exitstatus != 0
         raise "bcn returned non-zero exitcode #{$?.exitstatus}"

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -5,8 +5,8 @@ describe Bcnd::Runner do
   before do
     ENV["TRAVIS"] = "true"
     ENV["GITHUB_TOKEN"] = "github_token"
-    ENV["MAINLINE_HERITAGE_TOKEN"] = "mainline_heritage_token"
-    ENV["STABLE_HERITAGE_TOKEN"] = "stable_heritage_token"
+    ENV["MAINLINE_APP_TOKEN"] = "mainline_app_token"
+    ENV["STABLE_APP_TOKEN"] = "stable_app_token"
     ENV["QUAY_TOKEN"] = "quay_token"
     ENV["TRAVIS_COMMIT"] = "aaaaaa"
     ENV["TRAVIS_REPO_SLUG"] = "org/repo"
@@ -49,7 +49,7 @@ describe Bcnd::Runner do
         .with(body: {image: "bbbbbb"}.to_json)
 
         runner = described_class.new
-        expect(runner).to receive(:system).with("bcn deploy -e staging --tag aaaaaa --heritage-token mainline_heritage_token 1> /dev/null") do
+        expect(runner).to receive(:system).with("bcn deploy -e staging --tag aaaaaa --app-token mainline_app_token 1> /dev/null") do
           system 'true'
         end
 
@@ -87,7 +87,7 @@ describe Bcnd::Runner do
         )
 
         runner = described_class.new
-        expect(runner).to receive(:system).with("bcn deploy -e production --tag aaaaaa --heritage-token stable_heritage_token 1> /dev/null") do
+        expect(runner).to receive(:system).with("bcn deploy -e production --tag aaaaaa --app-token stable_app_token 1> /dev/null") do
           system 'true'
         end
         expect{runner.deploy}.to_not raise_error


### PR DESCRIPTION
For backward compatibility, the previous environment variable names still can be used
