### PR TITLE
Increase build list limit from default (5) to 20

### DIFF
--- a/lib/bcnd/quay_io.rb
+++ b/lib/bcnd/quay_io.rb
@@ -49,7 +49,7 @@ module Bcnd
     end
 
     def automated_builds_for(repo:, git_sha:)
-      builds = conn.get(path: "/repository/#{repo}/build/")["builds"]
+      builds = conn.get(path: "/repository/#{repo}/build/?limit=20")["builds"]
       builds.select do |b|
         b["trigger_metadata"]["commit"] == git_sha.downcase
       end

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -20,7 +20,7 @@ describe Bcnd::Runner do
       end
 
       it "wait for quay build to be finished" do
-        stub1 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/build/").to_return(
+        stub1 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/build/?limit=20").to_return(
           body: {
             builds: [
               {


### PR DESCRIPTION
The default limit of the list builds API is 5. We had an issue where we restarted a travis build which initially ran 1 day ago and `bcnd` couldn't find the build for the git SHA that the travis build was building because since the travis build was created, more than 5 builds were created in quay. I think 20 is enough limit but if we have the same problem with limit 20, I'll increase the limit number again