### PR TITLE
do not tag if the tag exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache:
   - bundler
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.0
+  - 2.3.4
+  - 2.4.1
 script:
   - bundle exec rspec
   - mkdir /home/travis/bin

--- a/bcnd.gemspec
+++ b/bcnd.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'octokit', '~> 4.2'
   s.add_dependency 'rest-client', '~> 1.8'
-  s.add_development_dependency "rspec", '~> 3.2'
-  s.add_development_dependency "webmock", '~> 1.22'
+  s.add_development_dependency "rspec"
+  s.add_development_dependency "webmock"
 end

--- a/lib/bcnd/quay_io.rb
+++ b/lib/bcnd/quay_io.rb
@@ -93,10 +93,8 @@ module Bcnd
           "specificTag" => tag
         }
       )
-      tags = resp["tags"]
-      tags.find { |tag|
-        tag["end_ts"].nil?
-      }&.dig("docker_image_id")
+      tag = resp["tags"].find { |tag| tag["end_ts"].nil? }
+      tag.nil? ? nil : tag["docker_image_id"]
     end
 
     def put_tag(repo:, image_id:, tag:)

--- a/lib/bcnd/quay_io.rb
+++ b/lib/bcnd/quay_io.rb
@@ -96,7 +96,7 @@ module Bcnd
       tags = resp["tags"]
       tags.find { |tag|
         tag["end_ts"].nil?
-      }["docker_image_id"]
+      }&.dig("docker_image_id")
     end
 
     def put_tag(repo:, image_id:, tag:)

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -20,7 +20,14 @@ describe Bcnd::Runner do
       end
 
       it "wait for quay build to be finished" do
-        stub1 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/build/?limit=20").to_return(
+        stub1 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+                  .with(query: hash_including("specificTag" => "aaaaaa"))
+                  .to_return(
+                    body: {
+                      tags: []
+                    }.to_json
+                  )
+        stub2 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/build/?limit=20").to_return(
           body: {
             builds: [
               {
@@ -32,7 +39,7 @@ describe Bcnd::Runner do
             ]
           }.to_json
         )
-        stub2 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+        stub3 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
         .with(query: hash_including("specificTag" => "latest"))
         .to_return(
           body: {
@@ -45,7 +52,7 @@ describe Bcnd::Runner do
           }.to_json
         )
 
-        stub3 = stub_request(:put,   "https://quay.io/api/v1/repository/org/repo/tag/aaaaaa")
+        stub4 = stub_request(:put,   "https://quay.io/api/v1/repository/org/repo/tag/aaaaaa")
         .with(body: {image: "bbbbbb"}.to_json)
 
         runner = described_class.new
@@ -57,6 +64,7 @@ describe Bcnd::Runner do
         expect(stub1).to have_been_requested
         expect(stub2).to have_been_requested
         expect(stub3).to have_been_requested
+        expect(stub4).to have_been_requested
       end
     end
 

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -66,6 +66,33 @@ describe Bcnd::Runner do
         expect(stub3).to have_been_requested
         expect(stub4).to have_been_requested
       end
+
+      context "when the tag already exists" do
+        it "skips tagging" do
+          stub = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+                   .with(query: hash_including("specificTag" => "aaaaaa"))
+                   .to_return(
+                     body: {
+                       tags: [
+                         {
+                           "reversion" => false,
+                           "manifest_digest" => "sha256:97b6de52ce9d9d89766144e0a9a0fe4a151741ecd812884ce804f41bdb672419",
+                           "start_ts" => 1492592525,
+                           "name" => "aaaaaa",
+                           "docker_image_id" => "aacf174aa6cf1a9de0efb5e6164cbc2556965fa469e94725c0de596e1e01a2d1"
+                         },
+                       ]
+                     }.to_json
+                   )
+
+          runner = described_class.new
+          expect(runner).to receive(:system).with("bcn deploy -e staging --tag aaaaaa --heritage-token mainline_heritage_token 1> /dev/null") do
+            system 'true'
+          end
+          expect{runner.deploy}.to_not raise_error
+          expect(stub).to have_been_requested
+        end
+      end
     end
 
     context "when production branch" do


### PR DESCRIPTION
Found a bug where a current `latest` image is tagged with a wrong name if CI build is restarted.
When the same CI build is restarted, the tag of git sha is already added by the previous run so the wait and tagging process can be skipped, and if it's not skipped, `bcnd` might tag the `latest` image with wrong tag name. This PR resolves the issue