### PR TITLE
Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: ruby
 cache:
   - bundler
 rvm:
-  - 2.2
-  - 2.3.4
-  - 2.4.1
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 script:
   - bundle exec rspec
   - mkdir /home/travis/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.6
 script:
   - bundle exec rspec
-  - mkdir /home/travis/bin
+  - mkdir -p /home/travis/bin
   - echo 'echo $@' > /home/travis/bin/bcn
   - chmod +x /home/travis/bin/bcn
   - bundle exec bin/bcnd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
-FROM debian:jessie
+FROM ruby:2.6
 
+WORKDIR /app
+ADD Gemfile /app/
+ADD bcnd.gemspec /app/
+RUN bundle install
 ADD . /app

--- a/bcnd.gemspec
+++ b/bcnd.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rest-client', '~> 2.0'
   s.add_development_dependency "rspec"
   s.add_development_dependency "webmock"
+  s.add_development_dependency "stub_env"
 end

--- a/bcnd.gemspec
+++ b/bcnd.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'octokit', '~> 4.2'
-  s.add_dependency 'rest-client', '~> 1.8'
+  s.add_dependency 'rest-client', '~> 2.0'
   s.add_development_dependency "rspec"
   s.add_development_dependency "webmock"
 end

--- a/lib/bcnd/ci.rb
+++ b/lib/bcnd/ci.rb
@@ -32,12 +32,16 @@ module Bcnd
       case ci_service
       when :travis
         ENV['TRAVIS_PULL_REQUEST'] != 'false'
+      when :gitlab_ci
+        !!ENV['CI_MERGE_REQUEST_ID']
       end
     end
 
     def ci_service
       if ENV['TRAVIS']
         :travis
+      elsif ENV['GITLAB_CI']
+        :gitlab_ci
       else
         :unknown
       end
@@ -70,6 +74,10 @@ module Bcnd
         self.repository = ENV['TRAVIS_REPO_SLUG']
         self.commit     = ENV['TRAVIS_COMMIT']
         self.branch     = ENV['TRAVIS_BRANCH']
+      when :gitlab_ci
+        self.repository = ENV['CI_PROJECT_PATH']
+        self.commit     = ENV['CI_COMMIT_SHA']
+        self.branch     = ENV['CI_COMMIT_REF_NAME']
       end
     end
 

--- a/lib/bcnd/quay_io.rb
+++ b/lib/bcnd/quay_io.rb
@@ -99,6 +99,7 @@ module Bcnd
     end
 
     def put_tag(repo:, image_id:, tag:)
+      return if ENV["DRY_RUN"]
       conn.put(
         path: "/repository/#{repo}/tag/#{tag}",
         body: {

--- a/lib/bcnd/quay_io.rb
+++ b/lib/bcnd/quay_io.rb
@@ -81,6 +81,7 @@ module Bcnd
           return
         when :building
           print '.'
+          $stdout.flush
           sleep 5
         end
       end

--- a/lib/bcnd/runner.rb
+++ b/lib/bcnd/runner.rb
@@ -30,7 +30,7 @@ module Bcnd
         puts "Found the tagged image #{env.commit}"
       else
         quay.wait_for_automated_build(repo: env.quay_repository, git_sha: env.commit)
-        image_id = quay.docker_image_id_for_tag(repo: env.quay_repository, tag: 'latest') # FIXME
+        image_id = quay.docker_image_id_for_tag(repo: env.quay_repository, tag: env.branch)
         quay.put_tag(repo: env.quay_repository, image_id: image_id, tag: env.commit)
         puts "attached tag #{env.commit} to image #{image_id}"
       end

--- a/lib/bcnd/runner.rb
+++ b/lib/bcnd/runner.rb
@@ -8,7 +8,10 @@ module Bcnd
     end
 
     def deploy
-      return if env.pull_request?
+      if env.pull_request?
+        puts "Nothing to do for a pull request. Exiting."
+        return
+      end
 
       case env.deploy_stage
       when :mainline
@@ -56,7 +59,10 @@ module Bcnd
     end
 
     def bcn_deploy(tag, token)
-      system "bcn deploy -e #{env.deploy_environment} --tag #{tag} --heritage-token #{token} 1> /dev/null"
+      unless ENV['DRY_RUN']
+        system "bcn deploy -e #{env.deploy_environment} --tag #{tag} --heritage-token #{token} 1> /dev/null"
+      end
+
       puts "deploy triggered with tag #{tag} to #{env.deploy_environment} environment"
       if $?.exitstatus != 0
         raise "bcn returned non-zero exitcode #{$?.exitstatus}"

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -2,25 +2,25 @@ require 'spec_helper'
 require 'json'
 
 describe Bcnd::Runner do
-  before do
-    ENV["TRAVIS"] = "true"
-    ENV["GITHUB_TOKEN"] = "github_token"
-    ENV["MAINLINE_HERITAGE_TOKEN"] = "mainline_heritage_token"
-    ENV["STABLE_HERITAGE_TOKEN"] = "stable_heritage_token"
-    ENV["QUAY_TOKEN"] = "quay_token"
-    ENV["TRAVIS_COMMIT"] = "aaaaaa"
-    ENV["TRAVIS_REPO_SLUG"] = "org/repo"
-  end
+  describe "Travis CI" do
+    before do
+      stub_env("TRAVIS", "true")
+      stub_env("GITHUB_TOKEN", "github_token")
+      stub_env("MAINLINE_HERITAGE_TOKEN", "mainline_heritage_token")
+      stub_env("STABLE_HERITAGE_TOKEN", "stable_heritage_token")
+      stub_env("QUAY_TOKEN", "quay_token")
+      stub_env("TRAVIS_COMMIT", "aaaaaa")
+      stub_env("TRAVIS_REPO_SLUG", "org/repo")
+    end
 
-  describe "#deploy" do
     context "when master branch" do
       before do
-        ENV["TRAVIS_BRANCH"] = "master"
-        ENV["TRAVIS_PULL_REQUEST"] = "false"
+        stub_env("TRAVIS_BRANCH", "master")
+        stub_env("TRAVIS_PULL_REQUEST", "false")
       end
 
       it "wait for quay build to be finished" do
-        stub1 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+        stub1 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/tag/")
                   .with(query: hash_including("specificTag" => "aaaaaa"))
                   .to_return(
                     body: {
@@ -39,8 +39,8 @@ describe Bcnd::Runner do
             ]
           }.to_json
         )
-        stub3 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
-        .with(query: hash_including("specificTag" => "latest"))
+        stub3 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/tag/")
+        .with(query: hash_including("specificTag" => "master"))
         .to_return(
           body: {
             tags: [
@@ -52,7 +52,7 @@ describe Bcnd::Runner do
           }.to_json
         )
 
-        stub4 = stub_request(:put,   "https://quay.io/api/v1/repository/org/repo/tag/aaaaaa")
+        stub4 = stub_request(:put,  "https://quay.io/api/v1/repository/org/repo/tag/aaaaaa")
         .with(body: {image: "bbbbbb"}.to_json)
 
         runner = described_class.new
@@ -97,8 +97,136 @@ describe Bcnd::Runner do
 
     context "when production branch" do
       before do
-        ENV["TRAVIS_BRANCH"] = "production"
-        ENV["TRAVIS_PULL_REQUEST"] = "false"
+        stub_env("TRAVIS_BRANCH", "production")
+        stub_env("TRAVIS_PULL_REQUEST", "false")
+      end
+
+      it do
+        expect_any_instance_of(Octokit::Client).to receive(:compare) do
+          double(
+            merge_base_commit: double(sha: 'aaaaaa')
+          )
+        end
+
+        stub1 = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+        .with(query: hash_including("specificTag" => "aaaaaa"))
+        .to_return(
+          body: {
+            tags: [
+              {
+                end_ts: nil,
+                docker_image_id: 'bbbbbb'
+              }
+            ]
+          }.to_json
+        )
+
+        runner = described_class.new
+        expect(runner).to receive(:system).with("bcn deploy -e production --tag aaaaaa --heritage-token stable_heritage_token 1> /dev/null") do
+          system 'true'
+        end
+        expect{runner.deploy}.to_not raise_error
+      end
+    end
+  end
+
+  describe "GitLab CI" do
+    before do
+      stub_env("GITLAB_CI", "true")
+      stub_env("GITHUB_TOKEN", "github_token")
+      stub_env("MAINLINE_HERITAGE_TOKEN", "mainline_heritage_token")
+      stub_env("STABLE_HERITAGE_TOKEN", "stable_heritage_token")
+      stub_env("QUAY_TOKEN", "quay_token")
+      stub_env("CI_COMMIT_SHA", "aaaaaa")
+      stub_env("CI_PROJECT_PATH", "org/repo")
+    end
+
+    context "when master branch" do
+      before do
+        stub_env("CI_COMMIT_REF_NAME", "master")
+        stub_env("TRAVIS_PULL_REQUEST", nil)
+      end
+
+      it "wait for quay build to be finished" do
+        stub1 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/tag/")
+                  .with(query: hash_including("specificTag" => "aaaaaa"))
+                  .to_return(
+                    body: {
+                      tags: []
+                    }.to_json
+                  )
+        stub2 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/build/?limit=20").to_return(
+          body: {
+            builds: [
+              {
+                trigger_metadata: {
+                  commit: "aaaaaa"
+                },
+                phase: "complete"
+              }
+            ]
+          }.to_json
+        )
+        stub3 = stub_request(:get, "https://quay.io/api/v1/repository/org/repo/tag/")
+        .with(query: hash_including("specificTag" => "master"))
+        .to_return(
+          body: {
+            tags: [
+              {
+                end_ts: nil,
+                docker_image_id: 'bbbbbb'
+              }
+            ]
+          }.to_json
+        )
+
+        stub4 = stub_request(:put,  "https://quay.io/api/v1/repository/org/repo/tag/aaaaaa")
+        .with(body: {image: "bbbbbb"}.to_json)
+
+        runner = described_class.new
+        expect(runner).to receive(:system).with("bcn deploy -e staging --tag aaaaaa --heritage-token mainline_heritage_token 1> /dev/null") do
+          system 'true'
+        end
+
+        expect{runner.deploy}.to_not raise_error
+        expect(stub1).to have_been_requested
+        expect(stub2).to have_been_requested
+        expect(stub3).to have_been_requested
+        expect(stub4).to have_been_requested
+      end
+
+      context "when the tag already exists" do
+        it "skips tagging" do
+          stub = stub_request(:get,  "https://quay.io/api/v1/repository/org/repo/tag/")
+                   .with(query: hash_including("specificTag" => "aaaaaa"))
+                   .to_return(
+                     body: {
+                       tags: [
+                         {
+                           "reversion" => false,
+                           "manifest_digest" => "sha256:97b6de52ce9d9d89766144e0a9a0fe4a151741ecd812884ce804f41bdb672419",
+                           "start_ts" => 1492592525,
+                           "name" => "aaaaaa",
+                           "docker_image_id" => "aacf174aa6cf1a9de0efb5e6164cbc2556965fa469e94725c0de596e1e01a2d1"
+                         },
+                       ]
+                     }.to_json
+                   )
+
+          runner = described_class.new
+          expect(runner).to receive(:system).with("bcn deploy -e staging --tag aaaaaa --heritage-token mainline_heritage_token 1> /dev/null") do
+            system 'true'
+          end
+          expect{runner.deploy}.to_not raise_error
+          expect(stub).to have_been_requested
+        end
+      end
+    end
+
+    context "when production branch" do
+      before do
+        stub_env("CI_COMMIT_REF_NAME", "production")
+        stub_env("TRAVIS_PULL_REQUEST", nil)
       end
 
       it do

--- a/spec/bcnd/runner_spec.rb
+++ b/spec/bcnd/runner_spec.rb
@@ -132,6 +132,7 @@ describe Bcnd::Runner do
 
   describe "GitLab CI" do
     before do
+      stub_env("TRAVIS", nil)
       stub_env("GITLAB_CI", "true")
       stub_env("GITHUB_TOKEN", "github_token")
       stub_env("MAINLINE_HERITAGE_TOKEN", "mainline_heritage_token")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'bcnd'
 require 'webmock/rspec'
+require 'stub_env'
+
+RSpec.configure do |config|
+  config.include StubEnv::Helpers
+end


### PR DESCRIPTION
- Update travis and Dockerfile
 - Dockerfile is for development purpose only
- Update RestClient version because old version doesn't work with newer ruby versions
- Added support for GitLab CI
- Use `env.branch` instead of `latest` because on Quay.io, `latest` is not guranteed to be attached to master images